### PR TITLE
Make sure that public API on handler only run after initial playback

### DIFF
--- a/include/dmn-dmesg.hpp
+++ b/include/dmn-dmesg.hpp
@@ -366,10 +366,28 @@ public:
     auto isInConflictInternal() const -> bool;
 
     /**
+     * @brief Pause and wait until m_is_after_initial_playback is set true
+     *        (playback has been completed).
+     */
+    void isAfterInitialPlayback();
+
+    /**
      * @brief Internal helper to mark the handler as resolved. Must be called
      *        in the publisher's async thread context.
      */
     void resolveConflictInternal();
+
+    /**
+     * @brief Set m_is_after_initial_playback to true and notify all blocking
+     * threads.
+     */
+    void setAfterInitialPlayback();
+
+    /**
+     * @brief Set m_is_after_initial_playback to true and notify all blocking
+     * threads, and this method called and run in internal asynchronous context.
+     */
+    void setAfterInitialPlaybackInternal();
 
     /**
      * @brief Put the handler into conflict state and schedule the conflict
@@ -406,7 +424,7 @@ public:
 
     // Set true after the handler has received the initial playback of
     // last-known messages for each topic.
-    bool m_after_initial_playback{};
+    std::atomic_flag m_after_initial_playback{};
   }; // class Dmn_DMesgHandler
 
   /**
@@ -540,7 +558,7 @@ Dmn_DMesg::openHandler(U &&...arg) {
       {
         this->m_handlers.push_back(handler);
         this->playbackLastTopicDMesgPbInternal();
-        handler->m_after_initial_playback = true;
+        handler->setAfterInitialPlayback();
       },
       this, handler);
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -23,6 +23,7 @@ ADD_TEST_EXECUTABLE(dmn
                       dmn-test-dmesg-7
                       dmn-test-dmesg-8
                       dmn-test-dmesg-9
+                      dmn-test-dmesg-10
                       dmn-test-dmesgnet-1
                       dmn-test-dmesgnet-2
                       dmn-test-dmesgnet-3

--- a/test/dmn-test-dmesg-10.cpp
+++ b/test/dmn-test-dmesg-10.cpp
@@ -1,0 +1,141 @@
+/**
+ * Copyright © 2025 Chee Bin HOH. All rights reserved.
+ *
+ * @file dmn-test-dmesg-1.cpp
+ * @brief The unit test that asserts that the dmn-dmesg with one publisher and
+ *        two subscribers work.
+ */
+
+#include <gtest/gtest.h>
+
+#include <chrono>
+#include <iostream>
+#include <thread>
+
+#include "proto/dmn-dmesg-type.pb.h"
+#include "proto/dmn-dmesg.pb.h"
+
+#include "dmn-dmesg.hpp"
+#include "dmn-proc.hpp"
+
+int main(int argc, char *argv[]) {
+  ::testing::InitGoogleTest(&argc, argv);
+
+  dmn::Dmn_DMesg dmesg{"dmesg"};
+
+  auto dmesg_write_handle = dmesg.openHandler("writeHandler");
+  EXPECT_TRUE(dmesg_write_handle);
+
+  auto dmesg_read_handle1 = dmesg.openHandler("readHandler1");
+
+  auto dmesg_read_handle2 = dmesg.openHandler(
+      "readHandler2", [](const dmn::DMesgPb &dmesgpb) -> bool {
+        return dmesgpb.body().message() != "message string 1";
+      });
+
+  dmn::DMesgPb dmesgpb1{};
+  dmesgpb1.set_topic("id1");
+  dmesgpb1.set_runningcounter(99);
+  dmesgpb1.set_sourceidentifier("unknown");
+  dmesgpb1.set_type(dmn::DMesgTypePb::message);
+
+  dmn::DMesgBodyPb *dmesgpb_body1 = dmesgpb1.mutable_body();
+  dmesgpb_body1->set_message("message string 1");
+
+  dmn::DMesgPb dmesgpb2{};
+  dmesgpb2.set_topic("id1");
+  dmesgpb2.set_runningcounter(99);
+  dmesgpb2.set_sourceidentifier("unknown");
+  dmesgpb2.set_type(dmn::DMesgTypePb::message);
+
+  dmn::DMesgBodyPb *dmesgpb_body2 = dmesgpb2.mutable_body();
+  dmesgpb_body2->set_message("message string 2");
+
+  dmn::DMesgPb dmesgpb3 = dmesgpb2;
+  dmn::DMesgPb dmesgpb4 = dmesgpb3;
+  dmesgpb4.set_force(true);
+
+  dmn::Dmn_Proc proc_read1{
+      "read1", [&dmesg_read_handle1, &dmesgpb1]() -> void {
+        std::cout << "before read1\n";
+        auto dmesgpb_read = dmesg_read_handle1->read();
+        std::cout << "after read1, and proceed to validate read\n";
+        EXPECT_TRUE(dmesgpb_read->topic() == dmesgpb1.topic());
+        EXPECT_TRUE(dmesgpb_read->sourceidentifier() ==
+                    dmesgpb1.sourceidentifier());
+        EXPECT_TRUE(dmesgpb_read->runningcounter() ==
+                    dmesgpb1.runningcounter());
+        EXPECT_TRUE(dmesgpb_read->type() == dmesgpb1.type());
+        EXPECT_TRUE(dmesgpb_read->body().message() ==
+                    dmesgpb1.body().message());
+      }};
+
+  dmn::Dmn_Proc proc_read2{
+      "read2", [&dmesg_read_handle2, &dmesgpb2]() -> void {
+        std::cout << "before read2\n";
+        auto dmesgpb_read = dmesg_read_handle2->read();
+        std::cout << "after read2, and proceed to validate read\n";
+        EXPECT_TRUE(dmesgpb_read->topic() == dmesgpb2.topic());
+        EXPECT_TRUE(dmesgpb_read->sourceidentifier() ==
+                    dmesgpb2.sourceidentifier());
+        EXPECT_TRUE(dmesgpb_read->runningcounter() ==
+                    dmesgpb2.runningcounter());
+        EXPECT_TRUE(dmesgpb_read->type() == dmesgpb2.type());
+        EXPECT_TRUE(dmesgpb_read->body().message() ==
+                    dmesgpb2.body().message());
+      }};
+
+  proc_read1.exec();
+  proc_read2.exec();
+  dmn::Dmn_Proc::yield();
+
+  std::this_thread::sleep_for(std::chrono::seconds(3));
+  std::cout << "after sleep 3 seconds\n";
+
+  dmesg_write_handle->write(dmesgpb1);
+  dmesg_write_handle->write(dmesgpb2);
+
+  dmesg.waitForEmpty();
+  dmesg_read_handle1->waitForEmpty();
+  dmesg_read_handle2->waitForEmpty();
+
+  std::cout << "after sleep 5 seconds\n";
+  std::this_thread::sleep_for(std::chrono::seconds(5));
+
+  proc_read1.wait();
+  proc_read2.wait();
+
+  auto runningCounter = dmesg_write_handle->getTopicRunningCounter("id1");
+
+  std::cout << "topic runningCounter: " << runningCounter << "\n";
+
+  runningCounter--;
+  dmesg_write_handle->setTopicRunningCounter("id1", runningCounter);
+
+  runningCounter = dmesg_write_handle->getTopicRunningCounter("id1");
+  std::cout << "topic runningCounter: " << runningCounter << "\n";
+
+  auto ok = dmesg_write_handle->writeAndCheckConflict(dmesgpb3);
+  EXPECT_TRUE((!ok));
+  std::cout << "write without conflict: " << ok << "\n";
+
+  auto inConflict = dmesg_write_handle->isInConflict();
+  EXPECT_TRUE((inConflict));
+
+  ok = dmesg_write_handle->writeAndCheckConflict(dmesgpb4);
+  EXPECT_TRUE((ok));
+  std::cout << "write without conflict: " << ok << "\n";
+
+  auto dmesg_read_handle3 = dmesg.openHandler("readHandler3");
+
+  runningCounter = dmesg_read_handle3->getTopicRunningCounter("id1");
+  std::cout << "Running counter for read_handle3: " << runningCounter << "\n";
+  EXPECT_TRUE((3 == runningCounter));
+
+  dmesg.closeHandler(dmesg_write_handle);
+  dmesg.closeHandler(dmesg_read_handle1);
+  dmesg.closeHandler(dmesg_read_handle2);
+  dmesg.closeHandler(dmesg_read_handle3);
+
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
Playback of last topic message is run in asynchronous context after handle is opened and returned.

We want to make sure that all read, write or query of handle state is only after initial playback is completed.