### PR TITLE
improve comment of the module

### DIFF
--- a/include/dmn-buffer.hpp
+++ b/include/dmn-buffer.hpp
@@ -208,6 +208,13 @@ protected:
   virtual auto popOptional(bool wait) -> std::optional<T>;
 
   /**
+   * @brief Signal all waiting threads to wake up and return.
+   *
+   * Sets the m_shutdown flag and notifies all condition variables so
+   * that threads blocked in pop(), pop(count, timeout), or
+   * waitForEmpty() can observe the shutdown flag and return cleanly.
+   * This method is called by Dmn_Pipe's destructor via the protected
+   * interface.
    */
   void stop();
 

--- a/include/dmn-io.hpp
+++ b/include/dmn-io.hpp
@@ -42,15 +42,56 @@ template <typename T> class Dmn_Io {
 public:
   virtual ~Dmn_Io() noexcept = default;
 
+  /**
+   * @brief Read and return the next available item.
+   *
+   * The call blocks until data is available. Returns std::nullopt to
+   * signal end-of-stream (e.g. EOF, closed pipe, or unrecoverable
+   * error); callers should treat std::nullopt as a permanent stop
+   * condition and cease further reads.
+   *
+   * @return optional<T> containing the next item, or std::nullopt on
+   *         end-of-stream.
+   */
   virtual auto read() -> std::optional<T> = 0;
 
+  /**
+   * @brief Read up to @p count items, optionally waiting up to
+   *        @p timeout microseconds.
+   *
+   * The default implementation returns an empty vector. Concrete
+   * subclasses may override this to provide bulk-read semantics
+   * consistent with Dmn_Buffer::pop(count, timeout).
+   *
+   * @param count   Maximum number of items to return (must be > 0).
+   * @param timeout Maximum wait time in microseconds; 0 means wait
+   *                indefinitely.
+   * @return Vector of up to @p count items (possibly fewer on
+   *         timeout).
+   */
   virtual auto read([[maybe_unused]] size_t count,
                     [[maybe_unused]] long timeout = 0) -> std::vector<T> {
     return {};
   }
 
+  /**
+   * @brief Write (copy) an item to the sink.
+   *
+   * The lvalue overload; implementations SHOULD copy @p item if they
+   * need to retain it beyond the call.
+   *
+   * @param item The item to write.
+   */
   virtual void write(T &item) = 0;
 
+  /**
+   * @brief Write (move) an item to the sink.
+   *
+   * The rvalue overload; implementations SHOULD move from @p item to
+   * avoid an unnecessary copy.
+   *
+   * @param item The item to write (may be moved from).
+   */
   virtual void write(T &&item) = 0;
 };
 

--- a/include/kafka/dmn-dmesgnet-kafka.hpp
+++ b/include/kafka/dmn-dmesgnet-kafka.hpp
@@ -1,5 +1,29 @@
 /**
  * Copyright © 2025 Chee Bin HOH. All rights reserved.
+ *
+ * @file dmn-dmesgnet-kafka.hpp
+ * @brief Convenience wrapper that wires Dmn_DMesgNet to Apache Kafka I/O.
+ *
+ * Dmn_DMesgNet_Kafka is a thin composition class that instantiates a
+ * Dmn_Kafka consumer (input) and a Dmn_Kafka producer (output) and
+ * passes them to a Dmn_DMesgNet instance. The result is a
+ * network-aware DMesg node whose transport layer is backed by a Kafka
+ * broker instead of a raw socket.
+ *
+ * The class handles all Kafka-specific configuration detail
+ * (consumer group id, topic name, auto.offset.reset, acks, etc.) so
+ * callers only need to supply the common broker connection parameters
+ * (bootstrap.servers, SASL credentials, etc.) via a Dmn_Kafka::ConfigType
+ * map. The fixed Kafka topic used for cluster communication is
+ * "Dmn_dmesgnet".
+ *
+ * Handler management (openHandler / closeHandler) is forwarded
+ * directly to the underlying Dmn_DMesgNet instance so callers work
+ * with the standard Dmn_DMesgHandler API.
+ *
+ * See also:
+ *  - dmn-dmesgnet.hpp : Dmn_DMesgNet — the network-aware DMesg base.
+ *  - kafka/dmn-kafka.hpp : Dmn_Kafka — the Kafka Dmn_Io adapter.
  */
 
 #ifndef DMN_DMESGNET_KAFKA_HPP_

--- a/include/kafka/dmn-kafka-util.hpp
+++ b/include/kafka/dmn-kafka-util.hpp
@@ -1,5 +1,18 @@
 /**
  * Copyright © 2025 Chee Bin HOH. All rights reserved.
+ *
+ * @file dmn-kafka-util.hpp
+ * @brief Utility helpers for configuring librdkafka instances.
+ *
+ * This header provides a thin, type-safe wrapper around
+ * rd_kafka_conf_set() that returns a std::expected value instead of
+ * relying on an output error-string buffer. Use set_config() wherever
+ * you need to apply a single key/value pair to an rd_kafka_conf_t
+ * object and want idiomatic C++ error handling.
+ *
+ * The constant kKafkaErrorStringLength defines the size of the
+ * temporary error string buffer required by rd_kafka_conf_set() and
+ * should be used whenever that buffer is allocated on the stack.
  */
 
 #ifndef DMN_KAFKA_UTIL_HPP_

--- a/src/dmn-async.cpp
+++ b/src/dmn-async.cpp
@@ -2,9 +2,23 @@
  * Copyright © 2025 Chee Bin HOH. All rights reserved.
  *
  * @file dmn-async.cpp
- * @brief Header for Dmn_Async: a small helper that serializes asynchronous
- *        execution of client-provided tasks and provides optional rendezvous
- *        points for callers that need to wait for completion.
+ * @brief Implementation of Dmn_Async: a small helper that serializes
+ *        asynchronous execution of client-provided tasks and provides
+ *        optional rendezvous points for callers that need to wait for
+ *        completion.
+ *
+ * Dmn_Async_Wait::wait() blocks the calling thread until the
+ * associated task finishes (or propagates its exception).
+ *
+ * Dmn_Async::addExecTask() wraps the user function in a try/catch so
+ * that exceptions thrown by tasks do not terminate the background
+ * thread.
+ *
+ * addExecTaskWithWait() additionally captures any thrown exception in
+ * the Dmn_Async_Wait object so the waiter can observe it via wait().
+ *
+ * addExecTaskAfterInternal() re-enqueues itself until the target wall-
+ * clock time has been reached, then executes the user function.
  */
 
 #include "dmn-async.hpp"

--- a/src/dmn-dmesg-daemon.cpp
+++ b/src/dmn-dmesg-daemon.cpp
@@ -1,9 +1,18 @@
 /**
  * Copyright © 2025 Chee Bin HOH. All rights reserved.
  *
- * This is the dmn daemon that runs as after a system bootup,
- * and receive and read, write and process message from network
- * of distributed dmn nodes.
+ * @file dmn-dmesg-daemon.cpp
+ * @brief Entry point for the DMesg daemon process.
+ *
+ * This daemon is intended to run after system boot and provides a
+ * Dmn_Runtime_Manager main loop that can receive, process and forward
+ * messages across a network of distributed DMesg nodes.
+ *
+ * The current implementation contains a minimal test harness that
+ * sleeps for 10 seconds and then overrides the SIGTERM handler to
+ * demonstrate dynamic signal handler registration. In a production
+ * deployment this stub would be replaced with the full DMesgNet
+ * initialisation and I/O handler wiring.
  */
 
 #include <chrono>

--- a/src/dmn-dmesg.cpp
+++ b/src/dmn-dmesg.cpp
@@ -2,7 +2,24 @@
  * Copyright © 2025 Chee Bin HOH. All rights reserved.
  *
  * @file dmn-dmesg.cpp
- * @brief DMESG publisher/subscriber wrapper using Protobuf messages.
+ * @brief Implementation of Dmn_DMesg and its nested Dmn_DMesgHandler.
+ *
+ * This file provides the concrete implementation of the DMesg
+ * publisher/subscriber system, which exchanges messages using the
+ * generated Protobuf type dmn::DMesgPb.
+ *
+ * Key implementation areas:
+ * - Dmn_DMesgHandlerSub::notify(): the hot-path subscriber callback
+ *   that filters, routes, and buffers or async-delivers arriving
+ *   DMesgPb messages.
+ * - Dmn_DMesgHandler: manages per-topic running counters, conflict
+ *   detection, conflict callbacks, and the writeDMesgInternal() path
+ *   that stamps and publishes outbound messages.
+ * - Dmn_DMesg: the publisher side, including publishInternal() which
+ *   applies global conflict detection and advances per-topic running
+ *   counters, and openHandler()/closeHandler() lifecycle management.
+ * - Playback: newly registered handlers receive the last published
+ *   message for each topic via playbackLastTopicDMesgPbInternal().
  */
 
 #include "dmn-dmesg.hpp"

--- a/src/dmn-kafka-receiver.cpp
+++ b/src/dmn-kafka-receiver.cpp
@@ -1,5 +1,19 @@
-// For study purpose, and copy from
-// https://developer.confluent.io/get-started/c/
+/**
+ * Copyright © 2025 Chee Bin HOH. All rights reserved.
+ *
+ * @file dmn-kafka-receiver.cpp
+ * @brief Minimal stand-alone Kafka consumer example using Dmn_Kafka.
+ *
+ * This program creates a Dmn_Kafka consumer with hard-coded Confluent
+ * Cloud credentials and polls the "timer_counter" topic until a
+ * SIGINT is received, printing each consumed message to stdout. It is
+ * intended as a quick integration smoke-test / study example and
+ * should not be used in production (credentials must not be
+ * hard-coded in real deployments).
+ *
+ * Original reference:
+ *   https://developer.confluent.io/get-started/c/
+ */
 
 #include <signal.h>
 #include <stdlib.h>

--- a/src/dmn-kafka-sender.cpp
+++ b/src/dmn-kafka-sender.cpp
@@ -1,5 +1,18 @@
-// For study purpose, and copy from
-// https://developer.confluent.io/get-started/c/
+/**
+ * Copyright © 2025 Chee Bin HOH. All rights reserved.
+ *
+ * @file dmn-kafka-sender.cpp
+ * @brief Minimal stand-alone Kafka producer example using Dmn_Kafka.
+ *
+ * This program creates a Dmn_Kafka producer with hard-coded Confluent
+ * Cloud credentials and publishes ten numbered "heartbeat" messages to
+ * the "timer_counter" topic.  It is intended as a quick integration
+ * smoke-test / study example and should not be used in production
+ * (credentials must not be hard-coded in real deployments).
+ *
+ * Original reference:
+ *   https://developer.confluent.io/get-started/c/
+ */
 
 #include <iostream>
 #include <sstream>

--- a/src/dmn-proc.cpp
+++ b/src/dmn-proc.cpp
@@ -4,8 +4,9 @@
  * @file dmn-proc.cpp
  * @brief Lightweight RAII wrapper around native pthread functionality.
  *
- * This module provides a C++ wrapper around POSIX threads (pthread) with RAII 
- * semantics. It manages thread lifecycle and ensures proper cleanup on destruction.
+ * This module provides a C++ wrapper around POSIX threads (pthread) with RAII
+ * semantics. It manages thread lifecycle and ensures proper cleanup on
+ * destruction.
  */
 
 #include "dmn-proc.hpp"
@@ -45,7 +46,7 @@ void cleanupFuncToUnlockPthreadMutex(void *arg) {
  * it is set and the state transitions to "Ready".
  *
  * @param name Descriptive name for the process (for debugging/logging)
- * @param fnc Optional task function to be executed. Can be nullptr if task 
+ * @param fnc Optional task function to be executed. Can be nullptr if task
  *            is to be set later via setTask() or exec()
  */
 Dmn_Proc::Dmn_Proc(std::string_view name, const Dmn_Proc::Task &fnc)
@@ -103,7 +104,7 @@ auto Dmn_Proc::getState() const -> Dmn_Proc::State { return m_state; }
 /**
  * @brief Sets a new state and returns the previous state.
  *
- * This is an atomic state transition operation. Useful for comparing and 
+ * This is an atomic state transition operation. Useful for comparing and
  * swapping states.
  *
  * @param state The new state to set
@@ -121,7 +122,8 @@ auto Dmn_Proc::setState(State state) -> Dmn_Proc::State {
  * @brief Assigns a task function to be executed by the thread.
  *
  * The process must be in either New or Ready state. After assignment,
- * the state transitions to Ready, indicating the task is prepared for execution.
+ * the state transitions to Ready, indicating the task is prepared for
+ * execution.
  *
  * @param fnc The task function to assign. Must not be nullptr.
  * @throws std::runtime_error if process is not in New or Ready state
@@ -136,8 +138,8 @@ void Dmn_Proc::setTask(Dmn_Proc::Task fnc) {
 /**
  * @brief Waits for the running thread to complete execution.
  *
- * This method performs a pthread_join to synchronously wait for thread termination.
- * After successful join, the state transitions back to Ready.
+ * This method performs a pthread_join to synchronously wait for thread
+ * termination. After successful join, the state transitions back to Ready.
  *
  * @return true if the join succeeded (err == 0)
  * @throws std::runtime_error if thread is not running or pthread_join fails
@@ -209,7 +211,8 @@ auto Dmn_Proc::stopExec() -> bool {
  * @brief Initiates thread execution with the assigned task.
  *
  * Creates a new pthread and sets its state to Running. The thread is configured
- * to accept deferred cancellations. On failure, state is reverted to previous value.
+ * to accept deferred cancellations. On failure, state is reverted to previous
+ * value.
  *
  * @return true if pthread_create succeeded, false otherwise
  * @throws std::runtime_error if process is not in Ready state

--- a/src/kafka/dmn-dmesgnet-kafka.cpp
+++ b/src/kafka/dmn-dmesgnet-kafka.cpp
@@ -1,5 +1,13 @@
 /**
  * Copyright © 2025 Chee Bin HOH. All rights reserved.
+ *
+ * @file dmn-dmesgnet-kafka.cpp
+ * @brief Implementation of Dmn_DMesgNet_Kafka.
+ *
+ * Constructs a Dmn_Kafka consumer and producer from the supplied
+ * configuration and uses them as the input/output handlers of a
+ * Dmn_DMesgNet instance. All DMesgNet cluster traffic is routed
+ * through the fixed Kafka topic "Dmn_dmesgnet".
  */
 
 #include "kafka/dmn-dmesgnet-kafka.hpp"

--- a/src/kafka/dmn-kafka-util.cpp
+++ b/src/kafka/dmn-kafka-util.cpp
@@ -1,5 +1,12 @@
 /**
  * Copyright © 2025 Chee Bin HOH. All rights reserved.
+ *
+ * @file dmn-kafka-util.cpp
+ * @brief Implementation of the librdkafka configuration helper.
+ *
+ * Provides set_config(), a thin wrapper around rd_kafka_conf_set()
+ * that converts the C-style output-parameter error string into a
+ * std::expected return value for idiomatic C++ error handling.
  */
 
 #include "kafka/dmn-kafka-util.hpp"

--- a/src/kafka/dmn-kafka.cpp
+++ b/src/kafka/dmn-kafka.cpp
@@ -1,5 +1,26 @@
 /**
  * Copyright © 2025 Chee Bin HOH. All rights reserved.
+ *
+ * @file dmn-kafka.cpp
+ * @brief Implementation of Dmn_Kafka — a Dmn_Io adapter for Apache Kafka.
+ *
+ * This file implements the Dmn_Kafka class which wraps the librdkafka
+ * C library (rdkafka) to provide a Dmn_Io<std::string> interface for
+ * both producing and consuming Kafka messages.
+ *
+ * Key implementation notes:
+ * - Construction creates either a producer or consumer handle
+ *   (rd_kafka_t) based on the Role argument, then subscribes the
+ *   consumer to the configured topic.
+ * - write() is synchronous from the caller's perspective: it uses an
+ *   atomic flag (m_write_atomic_flag) to serialize concurrent writers
+ *   and blocks until the delivery report callback (producerCallback)
+ *   signals completion.
+ * - read() delegates to rd_kafka_consumer_poll() with the configured
+ *   timeout and returns std::nullopt on timeout or non-fatal errors
+ *   (e.g. RD_KAFKA_RESP_ERR__PARTITION_EOF).
+ * - The destructor closes the consumer session or flushes pending
+ *   producer messages before destroying the rd_kafka_t handle.
  */
 
 #include "kafka/dmn-kafka.hpp"


### PR DESCRIPTION
Several source files had bare copyright-only headers, undocumented public interfaces, and one file had an outright incorrect @brief. This PR brings all files up to a consistent Doxygen documentation standard.

File-level headers (previously bare copyright only)

include/kafka/dmn-kafka-util.hpp / .cpp — describes set_config() wrapper and kKafkaErrorStringLength include/kafka/dmn-dmesgnet-kafka.hpp / .cpp — describes Kafka-backed DMesgNet composition src/kafka/dmn-kafka.cpp — synchronous write, poll-based read, and object lifecycle Expanded file-level descriptions (previously one-liners)

src/dmn-async.cpp — fixed @brief from "Header for" → "Implementation of"; added description of addExecTask* error handling and the re-queue loop in addExecTaskAfterInternal src/dmn-dmesg.cpp — key areas: notify hot-path, conflict detection, playback, handler lifecycle src/dmn-dmesgnet.cpp — constructor flow, all four private helpers (createInputHandlerProc, createSubscriptHandler, createTimerProc, reconciliateDMesgPbSys) src/dmn-runtime.cpp — signal masking strategy, priority queues, coroutine scheduler, POSIX timer setup src/dmn-socket.cpp — UDP semantics, per-call sockaddr_in reconstruction (with existing FIXME noted) Method-level Doxygen added

include/dmn-io.hpp — all four virtual methods (read(), read(count, timeout), write(T&), write(T&&)) were undocumented include/dmn-buffer.hpp — fixed empty /** */ block on Dmn_Buffer::stop() Inline comments

src/dmn-dmesgnet.cpp — block comments before createSubscriptHandler and createTimerProc explain the filter logic and master-election state machine src/dmn-socket.cpp — read() EOF path and write(T&&) move delegation annotated Kafka example programs

src/dmn-kafka-sender.cpp / dmn-kafka-receiver.cpp — replaced bare study-purpose lines with proper @file Doxygen headers noting the Confluent Cloud hard-coded credentials are for smoke-test use only